### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This application provides a simplified interface or Multi-Channel Proxy (MCP) fo
 
 **Licensing:** This server integrates with an external license server (`smartlead-license-server`) to manage feature access based on user subscription tiers (e.g., Free, Basic, Premium). Availability of certain features and tool categories depends on the active license tier validated against the configured license server.
 
+<a href="https://glama.ai/mcp/servers/@jean-technologies/smartlead-mcp-server-local">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jean-technologies/smartlead-mcp-server-local/badge" alt="Smartlead Simplified Server MCP server" />
+</a>
+
 ## Core Features
 
 *   **Proxies Smartlead API:** Acts as an intermediary for Smartlead API calls.


### PR DESCRIPTION
This PR adds a badge for the [Smartlead Simplified MCP Server](https://glama.ai/mcp/servers/@jean-technologies/smartlead-mcp-server-local) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@jean-technologies/smartlead-mcp-server-local">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jean-technologies/smartlead-mcp-server-local/badge" alt="Smartlead Simplified Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.